### PR TITLE
feat: add an URL existence validation, before opening a new tab

### DIFF
--- a/docs/assets/js/scripts.js
+++ b/docs/assets/js/scripts.js
@@ -1,9 +1,19 @@
 const searchInput = document.getElementById('searchInput');
 const searchButton = document.getElementById('searchButton');
 
-searchButton.addEventListener('click', (e) => {
+searchButton.addEventListener('click', async (e) => {
   e.preventDefault();
   const searchValue = searchInput.value;
   const url = `https://github.com/elidianaandrade/dio-lab-open-source/tree/main/community/${encodeURIComponent(searchValue)}.md`; 
-  window.open(url, '_blank');
+
+  await fetch(url)
+          .then(res => {
+            if (res.status == 404)
+              window.alert("Esse usuário não existe no repositório!")
+            else
+              window.open(url, '_blank');
+          })
+          .catch(e => {
+            console.error(e);
+          })
 })


### PR DESCRIPTION
**Descrição**

Uma validação de **existência**, utilizando Fetch API, sobre o endereço gerado pelo input do usuário no campo de pesquisa.

**Tipo de alteração**

- [ ] Resolução do Desafio Profile README
- [ ] Correção de bug
- [x] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Outro (especifique)

**Checklist**

- [x] Minhas alterações não deletam partes do projeto
- [ ] Minhas alterações não introduzem novos problemas (**VER COMENTÁRIOS ADICIONAIS**)
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

**Comentários adicionais**

Há um problema relacionado ao CORS do site destino (_o próprio GitHub_), que não consegui solucionar apenas pela minha máquina. Esse problema acaba impedindo que façamos a requisição via Fetch. Suponho que pelo deploy do GitHub Pages esse acesso seja solucionado, mas ainda não tenho certeza.
