### PR TITLE
fix: github name was wrong in badges.md

### DIFF
--- a/utils/badges/badges.md
+++ b/utils/badges/badges.md
@@ -85,7 +85,7 @@
         <img align="center" alt="GitHub" src="https://img.shields.io/badge/GitHub-000?style=for-the-badge&logo=github">
       </td>
       <td>
-        <code>[![GitHub](https://img.shields.io/badge/GitHbt-000?style=for-the-badge&logo=github&logoColor=white)](+https://github.com/SEUUSERNAME)</code>
+        <code>[![GitHub](https://img.shields.io/badge/GitHub-000?style=for-the-badge&logo=github&logoColor=white)](+https://github.com/SEUUSERNAME)</code>
       </td>
     </tr>
       <td>


### PR DESCRIPTION
# Descrição

correção: A badges esta com escrita errada no exemplo do github.

## Tipo de alteração

- [ ] Resolução do Desafio Profile README (envie APENAS o arquivo `community/SEU_USERNAME.md`)
- [ ] Correção de bug
- [ ] Nova funcionalidade
- [x] Alteração na documentação
- [ ] Outro (especifique)

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

### Comentários adicionais

Adicione aqui quaisquer comentários ou informações adicionais relevantes para o revisor.
