### PR TITLE
Link errado em badges.md

### DIFF
--- a/utils/badges/badges.md
+++ b/utils/badges/badges.md
@@ -45,7 +45,7 @@
         <img align="center" alt="Discord" src="https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white">
       </td>
       <td>
-        <code>[![Discord](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://https://discord.com/channels/@SEUUSERNAME/)</code>
+        <code>[![Discord](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/channels/@SEUUSERNAME/)</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Removed an extra https that was breaking the discord link.

# Descrição

Dentro do [badges.md](https://github.com/digitalinnovationone/dio-lab-open-source/blob/main/utils/badges/badges.md) o link do discord atualmente é https://https://discord.com/channels/@SEUUSERNAME/ ao invés de só https://discord.com/channels/@SEUUSERNAME/, o que quebra o link.
## Tipo de alteração

- [ ] Resolução do Desafio Profile README (envie APENAS o arquivo `community/SEU_USERNAME.md`)
- [X] Correção de bug
- [ ] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Outro (especifique)

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

### Comentários adicionais

Chequei e havia um issue aberto já falando sobre esse problema, porém como é algo simples e faz um certo tempo que esse issue está aberto decidi criar um pull.
