### PR TITLE
feat: add youtube badge in social group

### DIFF
--- a/utils/badges/badges.md
+++ b/utils/badges/badges.md
@@ -82,6 +82,14 @@
     </tr>
     <tr>
       <td>
+        <img align="center" alt="YouTube-badge" src="https://img.shields.io/badge/YouTube-001?style=for-the-badge&logo=youtube&logoColor=FF0000&labelColor=FFFFFF&color=282828">
+      </td>
+      <td>
+        <code>[![YouTube](https://img.shields.io/badge/YouTube-001?style=for-the-badge&logo=youtube&logoColor=FF0000&labelColor=FFFFFF&color=282828)](https://www.youtube.com/@SEUCANAL)</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <img align="center" alt="GitHub" src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white">
       </td>
       <td>


### PR DESCRIPTION
# Descrição

Adição do badge do YouTube na tabela de bagdes de redes sociais

## Tipo de alteração

- [ ] Resolução do Desafio Profile README (envie APENAS o arquivo `community/SEU_USERNAME.md`)
- [ ] Correção de bug
- [ ] Nova funcionalidade
- [x] Alteração na documentação
- [ ] Outro (especifique)

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

### Comentários adicionais

Cores utilizadas seguindo a documentação do YouTube sobre a marca: [Brand resources
](https://www.youtube.com/howyoutubeworks/resources/brand-resources/#logos-icons-and-colors)