### PR TITLE
Adiciona script para listar perfis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,13 @@ docs/
 └── README.md
 ```
 
+## Scripts Úteis
+
+### Listar Perfis
+Para listar todos os perfis disponíveis, execute o script `list_profiles.py`:
+```bash
+python scripts/list_profiles.py
+
 ## Tecnologias
 ![HTML](https://img.shields.io/badge/HTML-000?style=for-the-badge&logo=html5&logoColor=30A3DC)
 ![CSS](https://img.shields.io/badge/CSS-000?style=for-the-badge&logo=css3&logoColor=E94D5F)


### PR DESCRIPTION
Este PR adiciona um script em Python (`list_profiles.py`) que lista todos os perfis disponíveis na pasta `profiles/`.
O script verifica se a pasta existe e exibe os nomes dos arquivos de perfil sem a extensão `.md`.

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

