### PR TITLE
Adicionando funcionalidade de criação de badge com o nome do último commiter

### DIFF
--- a/utils/last-commiter/README.md
+++ b/utils/last-commiter/README.md
@@ -1,0 +1,19 @@
+# 🏷️ Badge - Último Commit por (usuário)
+
+Este script gera um badge SVG com o nome do autor do último commit em um repositório GitHub.
+
+## Rodar no terminal
+
+Requisitos: Node.js
+
+```bash
+node utils/last-committer.js <user> <repo>
+```
+
+Exemplo:
+
+```bash
+node utils/last-committer.js digitalinnovationone dio-lab-open-source
+```
+
+O arquivo será salvo em `badges/badge-last-committer.svg`.

--- a/utils/last-commiter/last-commiter.js
+++ b/utils/last-commiter/last-commiter.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const https = require('https');
+
+const owner = process.argv[2] || 'digitalinnovationone';
+const repo = process.argv[3] || 'dio-lab-open-source';
+const badgePath = `badges/badge-last-committer.svg`;
+
+function fetchLastCommitter(callback) {
+  const options = {
+    hostname: 'api.github.com',
+    path: `/repos/${owner}/${repo}/commits`,
+    headers: { 'User-Agent': 'Node.js' }
+  };
+
+  https.get(options, (res) => {
+    let data = '';
+    
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => {
+      try {
+        const commits = JSON.parse(data);
+        const humanCommit = commits.find(c => !c.author?.login?.includes('[bot]'));
+        const username = humanCommit?.author?.login || 'Desconhecido';
+        
+        callback(username);
+      } catch (err) {
+        console.error('Erro ao processar resposta da API:', err);
+      }
+    });
+  }).on('error', err => {
+    console.error('Erro na requisição HTTPS:', err);
+  });
+}
+
+function generateBadge(username) {
+  const svg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="20">
+  <rect width="140" height="20" fill="#555"/>
+  <rect x="140" width="80" height="20" fill="#007ec6"/>
+  <text x="10" y="14" fill="#fff" font-family="Verdana" font-size="11">último commit por</text>
+  <text x="145" y="14" fill="#fff" font-family="Verdana" font-size="11">${username}</text>
+</svg>
+  `.trim();
+
+  fs.mkdirSync('badges', { recursive: true });
+  fs.writeFileSync(badgePath, svg);
+  console.log(`✅ Badge gerado com sucesso: ${badgePath}`);
+}
+
+fetchLastCommitter(generateBadge);


### PR DESCRIPTION
# Descrição

Descrição da alteração que está sendo proposta.

## Tipo de alteração

- [ ] Resolução do Desafio Profile README (envie APENAS o arquivo `community/SEU_USERNAME.md`)
- [x] Correção de bug
- [ ] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Outro (especifique)

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

### Comentários adicionais

Introduzi uma nova funcionalidade que gera um badge na pasta badges/ com o nome do último "commitador". Achei interessante, visto que existem muitos contribuidores e a partir do 1000 não é mostrado mais o nome. Possíveis implementações são criar uma lista com os últimos 100 colaboradores, melhorar o estilo, aplicar o badge ao README principal etc.