### PR TITLE
feat: adiciona busca dinâmica por perfil do LinkedIn

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -202,11 +202,11 @@ main, section {
     gap: 1rem;
 }
 
-#searchForm {
+#searchForm, #searchLinkedinForm {
     display: flex;
 }
 
-#searchButton {
+#searchButton, #searchLinkedinButton {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -222,24 +222,28 @@ main, section {
     transition: all 1s ease;
 }
 
-#searchButton span {
+#searchLinkedinButton {
+    padding-right: .50rem;
+}
+
+#searchButton span, #searchLinkedinButton span {
     font-size: .85rem;
     font-weight: 600;
     letter-spacing: .1rem;
     padding-left: .5rem;
 }
 
-#searchButton i {
+#searchButton i, #searchLinkedinButton i {
     font-size: 1.5rem;
 }
 
-#searchButton:hover {
+#searchButton:hover, #searchLinkedinButton:hover {
     color: var(--white);
     background-color: #0F0F0F;
     border: #0F0F0F;
 }
 
-#searchInput {
+#searchInput, #searchLinkedinInput {
     max-width: 100%;
     font-size: 1rem;
     border: .125rem solid var(--secondary-color);
@@ -248,7 +252,7 @@ main, section {
     cursor: pointer; 
 }
 
-#searchInput:focus {
+#searchInput:focus, #searchLinkedinInput:focus {
     box-shadow: inset 0 1.125rem 5rem 0 rgba(153, 153, 153, 0.3);
     outline: 0;
 }

--- a/docs/assets/js/scripts.js
+++ b/docs/assets/js/scripts.js
@@ -15,3 +15,41 @@ searchButton.addEventListener('click', (e) => {
   }
   window.open(url, '_blank');
 })
+
+const searchLinkedinInput = document.getElementById('searchLinkedinInput');
+const searchLinkedinButton = document.getElementById('searchLinkedinButton');
+
+searchLinkedinButton.addEventListener('click', (e) => {
+    e.preventDefault();
+    const searchValue = searchLinkedinInput.value;
+
+    if (searchValue === '') {
+        alert('Por favor, insira um nome de usuário do GitHub.');
+        return;
+    }
+
+    const fileUrl = `https://raw.githubusercontent.com/digitalinnovationone/dio-lab-open-source/main/community/${encodeURIComponent(searchValue)}.md`;
+
+    fetch(fileUrl)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Perfil do GitHub não encontrado.');
+            }
+            return response.text();
+        })
+        .then(data => {
+            // NOVA EXPRESSÃO REGULAR: mais flexível para encontrar qualquer URL do LinkedIn
+            const regex = /https?:\/\/(?:www\.)?linkedin\.com\/in\/[^\s/]+/i;
+            const match = data.match(regex);
+
+            if (match) {
+                const linkedinUrl = match[0];
+                window.open(linkedinUrl, '_blank');
+            } else {
+                alert('Link do LinkedIn não encontrado no perfil do GitHub.');
+            }
+        })
+        .catch(error => {
+            alert(error.message);
+        });
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,12 +128,22 @@
                 </a> 😉🚀.
             </p>
             <form id="searchForm">
-                <input type="text" id="searchInput" placeholder="username" value="falvojr" minlength="3" maxlength="39">
+                <input type="text" id="searchInput" placeholder="username" minlength="3" maxlength="39">
                 <button type="submit" id="searchButton">
                     <span>Ver Perfil</span>
                     <i class="bi bi-github"></i>
                 </button>
             </form>
+
+            <h2>Encontre o LinkedIn da comunidade</h2>
+            <p>Localize o LinkedIn das pessoas que colaboraram e aumente a sua rede!</p>
+            <form id="searchLinkedinForm">
+            <input type="text" id="searchLinkedinInput" placeholder="username" minlength="3">
+            <button type="submit" id="searchLinkedinButton">
+                <span>Ver LinkedIn</span>
+                <i class="bi bi-linkedin"></i>
+            </button>
+</form>
         </section>
 
         <section id="materiais">


### PR DESCRIPTION
Adiciona busca por perfil do LinkedIn de forma dinâmica da seguinte forma:

- Obtém o nome de usuário do GitHub.
- Faz um fetch do conteúdo do arquivo markdown (community/nome-de-usuario.md).
- Procura por uma URL do LinkedIn no conteúdo do arquivo usando uma regex flexível.
- Abre o link encontrado em uma nova aba.
>

Essa edição melhora a experiência do usuário, permitindo que além da busca pelo perfil do GitHub o usuário possa encontrar os perfis de Linkedin de todos que já contribuiram no projeto efetuando a busca também pelo nome de usuário do GitHub, que é o identificador consistente no projeto.

# Descrição

Descrição da alteração que está sendo proposta.

## Tipo de alteração

- [ ] Resolução do Desafio Profile README (envie APENAS o arquivo `community/SEU_USERNAME.md`)
- [ ] Correção de bug
- [x] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Outro (especifique)

## Checklist

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição está de acordo com o [Guia de Contribuição](https://github.com/elidianaandrade/dio-lab-open-source/blob/main/CONTRIBUTING.md)

### Comentários adicionais

N/A