### PR TITLE
docs: adiciona perfil de Gabriel Amancio Ferreira em docs/profiles

### DIFF
--- a/docs/profiles/gabriel-amancio-ferreira.md
+++ b/docs/profiles/gabriel-amancio-ferreira.md
@@ -1,0 +1,16 @@
+# Gabriel Amancio Ferreira
+
+**Cargo:** Analista de Dados | BI  
+**Empresa:** Join – Gestão & Análise  
+**Áreas de Interesse:** Business Intelligence, Power BI, Python, SQL, ETL, Automação de Relatórios  
+
+**Sobre:**  
+Profissional apaixonado por dados e tecnologia. Atua na Join – Gestão & Análise com desenvolvimento de dashboards e automação de processos em BI, integrando dados financeiros, jurídicos e administrativos para gerar insights estratégicos.  
+Interessado em projetos open source e em aprimorar práticas de análise e visualização de dados.
+
+**GitHub:** https://github.com/gabamancio 
+**LinkedIn:** https://www.linkedin.com/in/gabrielamanciofe
+
+## Minhas contribuições neste repositório
+- Inclusão do perfil profissional em `docs/profiles/`.
+- Contribuição voltada à prática de versionamento e colaboração no GitHub.


### PR DESCRIPTION
# Descrição

Este PR adiciona o perfil profissional de Gabriel Amancio Ferreira em `docs/profiles/gabriel-amancio-ferreira.md`,  
como parte do Lab "Contribuindo em um Projeto Open Source no GitHub" (DIO).

## Tipo de alteração
- [x] Documentação (perfil de participante)

## Checklist
- [x] Minhas alterações não deletam partes do projeto.
- [x] Minhas alterações não introduzem novos problemas.
- [x] Minha contribuição segue o guia de contribuição do repositório.

## Comentários adicionais
Gabriel atua como Analista de Dados e BI na Join – Gestão & Análise,  
com foco em Power BI, SQL, DAX e automação de relatórios.
