### PR TITLE
docs: adiciona nota sobre conflito de paths no Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,20 @@ Após criar o seu Pull Request, nossa automação irá validar a sua submissão.
 - [ANGULAR. Contributing to Angular](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md)
 - [CONVENTIONAL COMMITS. Summary](https://www.conventionalcommits.org/en/v1.0.0/)
 - [GITHUB. Configurar diretrizes para os contribuidores do repositório](https://docs.github.com/pt/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
+
+## ⚠ Problema conhecido: conflito de paths no Windows
+
+Alguns usuários no Windows podem encontrar o seguinte erro ao fazer `git clone`:
+
+warning: the following paths have collided (e.g. case-sensitive paths
+on a case-insensitive filesystem) and only one from the same
+colliding group is in the working tree:
+'community/EduMagalhaess.md'
+'community/edumagalhaess.md'
+
+Esse erro ocorre porque o Windows não diferencia letras maiúsculas e minúsculas em nomes de arquivos, causando conflito quando dois arquivos possuem o mesmo nome, variando apenas pelo uso de maiúsculas/minúsculas.
+
+### ✔ Como resolver
+- Renomear um dos arquivos conflitantes diretamente no GitHub antes de fazer o clone;  
+- Ou usar WSL2 / Linux, que é case-sensitive;  
+- Ou excluir o repositório local e clonar novamente após as correções no repositório remoto.


### PR DESCRIPTION
Este Pull Request adiciona uma explicação detalhada sobre o erro de path collision no Windows, que ocorre devido às diferenças entre barras invertidas (\) e barras comuns (/) ao utilizar comandos do Git no sistema operacional.

O objetivo é ajudar outros usuários a entenderem o motivo do problema e como resolvê-lo de forma simples, evitando erros futuros durante o uso do repositório ou na execução das instruções do desafio.

Alterações incluídas

Adicionada orientação para lidar com colisão de paths no Windows.

Explicação clara da causa do problema e de como contorná-lo.

Conteúdo adicionado ao arquivo CONTRIBUTING.md para orientar novos colaboradores.

Motivação

Durante o processo de contribuição, o erro ocorreu devido à forma como o Windows interpreta paths. Documentar essa situação aumenta a acessibilidade do projeto, facilita a contribuição de novos participantes e melhora a experiência de uso para quem utiliza Windows.